### PR TITLE
Fix issue with a conversion script

### DIFF
--- a/docs/benchmarks/nyc-taxi-benchmark-runbook.md
+++ b/docs/benchmarks/nyc-taxi-benchmark-runbook.md
@@ -70,7 +70,7 @@ def convert_parquet_to_tsv(input_directory, output_directory):
         df = pd.read_parquet(parquet_file)
         base_name = os.path.basename(parquet_file)
         tsv_file = os.path.join(output_directory, base_name.replace('.parquet', '.tsv'))
-        df.to_csv(tsv_file, index=False)
+        df.to_csv(tsv_file, sep='\t', index=False)
         print(f"Converted {parquet_file} to {tsv_file}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This script is supposed to convert parquet to TSV, but without specifying the separator it was converting it to CSV