### PR TITLE
fix: image paths fixed

### DIFF
--- a/docs/instrument-traces/dotnet-app.md
+++ b/docs/instrument-traces/dotnet-app.md
@@ -5,15 +5,19 @@
 In this tutorial, we will go through the steps to auto-instrument a .NET app to send traces to Siglens.
 
 ## Prerequisites
+
 - You need to have the .NET SDK installed. You can install `dotnet` using a package manager like homebrew or download it [here](https://dotnet.microsoft.com/en-us/download/dotnet).
 
 ## Quickstart
+
 Start SigLens:
+
 ```bash
 curl -L https://siglens.com/install.sh | sh
 ```
 
 Setup a .NET app:
+
 ```bash
 mkdir dotnet-example
 cd dotnet-example
@@ -21,6 +25,7 @@ dotnet new web
 ```
 
 Replace the default `Program.cs`:
+
 ```bash
 echo 'using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
@@ -41,6 +46,7 @@ app.Run();' > Program.cs
 ```
 
 Replace the default `Properties/launchSettings.json`:
+
 ```bash
 echo '{
   "$schema": "http://json.schemastore.org/launchsettings.json",
@@ -59,6 +65,7 @@ echo '{
 ```
 
 Install OpenTelemetry dependencies:
+
 ```bash
 dotnet add package OpenTelemetry
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
@@ -69,6 +76,7 @@ dotnet add package OpenTelemetry.AutoInstrumentation
 ```
 
 Run the app:
+
 ```bash
 OTEL_METRICS_EXPORTER=none \
 OTEL_LOGS_EXPORTER=none \
@@ -82,9 +90,12 @@ Go to the app at http://localhost:8080 and refresh the page a few times (you sho
 After about 10 seconds, you should see the traces on SigLens on http://localhost:5122 then going to Tracing -> Search Traces and clicking the Find Traces button.
 
 ## More Details
+
 For auto-instrumenting your own .NET app, you'll follow a similar procedure.
 In particular, you will:
+
 1. Add the following to your program:
+
 ```csharp
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
@@ -99,7 +110,9 @@ builder.Services.AddOpenTelemetry()
 
 var app = builder.Build();
 ```
+
 2. Install OpenTelemetry dependencies into your project:
+
 ```bash
 dotnet add package OpenTelemetry
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
@@ -108,7 +121,9 @@ dotnet add package OpenTelemetry.Instrumentation.Runtime
 dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 dotnet add package OpenTelemetry.AutoInstrumentation
 ```
+
 3. Run your app using OTEL environment variables:
+
 ```bash
 OTEL_METRICS_EXPORTER=none \
 OTEL_LOGS_EXPORTER=none \
@@ -120,10 +135,10 @@ dotnet run
 
 Once you're on the Tracing tab of SigLens, you can search the traces and see health metrics and graphs for each service.
 
-![search-dotnet](/static/tutorials/dotnet-search.png)
+![search-dotnet](../../static/tutorials/dotnet-search.png)
 
-![metrics-dotnet](/static/tutorials/dotnet-metrics.png)
+![metrics-dotnet](../../static/tutorials/dotnet-metrics.png)
 
-![dotnet-graph-1](/static/tutorials/dotnet-graph-1.png)
+![dotnet-graph-1](../../static/tutorials/dotnet-graph-1.png)
 
-![dotnet-graph-2](/static/tutorials/dotnet-graph-2.png)
+![dotnet-graph-2](../../static/tutorials/dotnet-graph-2.png)

--- a/docs/instrument-traces/python-app.md
+++ b/docs/instrument-traces/python-app.md
@@ -6,12 +6,15 @@ In this tutorial, we will go through the steps to auto-instrument a Python app t
 Follow along with the [Django Quickstart](#django-quickstart) or [Flask Quickstart](#flask-quickstart) to quickly get an app sending traces to SigLens, then checkout [More Details](#more-details) for more information on getting your existing app to send traces to SigLens.
 
 ## Django Quickstart
+
 Start SigLens:
+
 ```bash
 curl -L https://siglens.com/install.sh | sh
 ```
 
 Setup a simple Python app:
+
 ```bash
 git clone https://github.com/docker/awesome-compose.git
 cd awesome-compose/django/app
@@ -21,6 +24,7 @@ pip install -r requirements.txt
 ```
 
 Install packages for OpenTelemetry Python development:
+
 ```bash
 pip install opentelemetry-exporter-otlp-proto-http
 pip install opentelemetry-distro
@@ -28,11 +32,13 @@ opentelemetry-bootstrap -a install
 ```
 
 Install packages for OpenTelemetry Python development with Django:
+
 ```bash
 pip install opentelemetry-instrumentation-django
 ```
 
 Run with OpenTelemetry auto-instrumentation:
+
 ```bash
 DJANGO_SETTINGS_MODULE=example.settings \
 OTEL_LOGS_EXPORTER=none \
@@ -47,12 +53,15 @@ Go to the app at http://localhost:8000 and refresh the page a few times (you sho
 After about 10 seconds, you should see the traces on SigLens on http://localhost:5122 then going to Tracing -> Search Traces and clicking the Find Traces button.
 
 ## Flask Quickstart
+
 Start SigLens:
+
 ```bash
 curl -L https://siglens.com/install.sh | sh
 ```
 
 Setup a simple Python app:
+
 ```bash
 git clone https://github.com/helloflask/flask-examples.git
 cd flask-examples/hello
@@ -61,6 +70,7 @@ source flask/bin/activate
 ```
 
 Install packages for OpenTelemetry Python development:
+
 ```bash
 pip install opentelemetry-exporter-otlp-proto-http
 pip install opentelemetry-distro
@@ -68,12 +78,14 @@ opentelemetry-bootstrap -a install
 ```
 
 Install packages for OpenTelemetry Python development with Flask:
+
 ```bash
 pip install 'flask<3' 'werkzeug<3'
 pip install opentelemetry-instrumentation-flask
 ```
 
 Run with OpenTelemetry auto-instrumentation:
+
 ```bash
 OTEL_LOGS_EXPORTER=none \
 OTEL_METRICS_EXPORTER=none \
@@ -87,6 +99,7 @@ Go to the app at http://localhost:8080 and refresh the page a few times (you sho
 After about 10 seconds, you should see the traces on SigLens on http://localhost:5122 then going to Tracing -> Search Traces and clicking the Find Traces button.
 
 ## More Details
+
 To auto-instrument your own Flask or Django app, you'll follow a similar procedure as in the relevant Quickstart.
 For a Python app using a different framework the process will be largely the same, but instead of installing `opentelemetry-instrumentation-flask` you'll install `opentelemetry-instrumentation-<package>`.
 Check out the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) to find the appropriate package for instrumenting your Python app.
@@ -95,11 +108,10 @@ For Django specifically, you need to run the app with the `--noreload` flag, so 
 
 Once you're on the Tracing tab of SigLens, you can search the traces and see health metrics and graphs for each service.
 
-![search-python](/static/tutorials/search-traces-py.png)
+![search-python](../../static/tutorials/search-traces-py.png)
 
-![metrics-python](/static/tutorials/metrics-python.png)
+![metrics-python](../../static/tutorials/metrics-python.png)
 
-![metrics-python-graph-1](/static/tutorials/metrics-graph-1-py.png)
+![metrics-python-graph-1](../../static/tutorials/metrics-graph-1-py.png)
 
-![metrics-python-graph-2](/static/tutorials/metrics-graph-2-py.png)
-
+![metrics-python-graph-2](../../static/tutorials/metrics-graph-2-py.png)


### PR DESCRIPTION
#Description
- The image reference paths for Python and .Net documentation in the instrument traces are aligned to share the common `../../static prefix` used by other applications.


The current live version at Netlify: https://singular-kelpie-6480de.netlify.app/