### PR TITLE
Docs: Migrating/Streaming of logs from AWS CloudWatch

### DIFF
--- a/docs/migration/awscloudwatch/aws-lambda.md
+++ b/docs/migration/awscloudwatch/aws-lambda.md
@@ -42,9 +42,10 @@ import TabItem from '@theme/TabItem';
 4. Click `Add`.
 
 ### 3. Environment Variables Setup
-Set the following variables in the AWS Lambda function:
-- `SIGLENS_INGEST_URL`: `https://yourhost.com:8081/services/collector/event`.
-- `SIGLENS_TOKEN`: Ingestion token, e.g., `A94A8FE5CCB19BA61C4C08`.
+Configure the following environment variables in your AWS Lambda function:
+- **SIGLENS_INGEST_URL**: Specify the endpoint for log ingestion, for example, `https://yourhost.com:8081/services/collector/event`.
+- **SIGLENS_TOKEN**: This is the ingestion token required for authenticating requests to SigLens. Use this if you are utilizing a SigLens SaaS account. To find your ingestion token, navigate to `My Org` -> `API Keys` -> `Ingest Token` within your SigLens dashboard.
+
 
 ### 4. Lambda Function Deployment
 1. In the Code section, navigate to `index.mjs`, replace its contents with the below code, and save.

--- a/docs/migration/awscloudwatch/aws-lambda.md
+++ b/docs/migration/awscloudwatch/aws-lambda.md
@@ -1,0 +1,264 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# AWS Lambda
+
+*Migrating/Stream Logs from AWS CloudWatch to SigLens through AWS Lambda.*
+
+
+### 1. AWS Lambda Function Setup
+
+**Prerequisites**: AWS account with logs in CloudWatch Logs Group.
+
+#### Set IAM Permissions
+1. In AWS Lambda Console, create a new Node.js function.
+2. Assign custom IAM role with permissions:
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "logs:CreateLogGroup",
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+3. Click `Create function`.
+
+### 2. CloudWatch Trigger Configuration
+1. In your Lambda function, go to Configuration > Triggers.
+2. Click `Add Trigger`, choose `CloudWatch Logs` as the source.
+3. Select your log group, set a Filter name, and an optional Filter-pattern.
+4. Click `Add`.
+
+### 3. Environment Variables Setup
+Set the following variables in the AWS Lambda function:
+- `SIGLENS_INGEST_URL`: `https://yourhost.com:8081/services/collector/event`.
+- `SIGLENS_TOKEN`: Ingestion token, e.g., `A94A8FE5CCB19BA61C4C08`.
+
+### 4. Lambda Function Deployment
+1. In the Code section, navigate to `index.mjs`, replace its contents with the below code, and save.
+
+    <Tabs
+    className="bg-light"
+    defaultValue="nodejs"
+    values={[
+        {label: 'Node.js', value: 'nodejs'},
+    ]
+    }>
+
+    <TabItem value="nodejs">
+
+    <details>
+    <summary>index.mjs</summary>
+
+    ```javascript
+    /**
+     * Stream events from AWS CloudWatch Logs to SigLens
+     *
+     * This function streams AWS CloudWatch Logs to SigLens using
+     * the SigLens HTTP event collector API.
+     *
+     * Define the following Environment Variables in the console below to configure
+     * this function to stream logs to your SigLens host:
+     *
+     * 1. SIGLENS_INGEST_URL: URL address for your SigLens HTTP event collector endpoint.
+     * Default port for event collector is 8081. Example: https://host.com:8081/services/collector/event
+     *
+     * 2. SIGLENS_TOKEN: Token for your SigLens HTTP event collector.
+     */
+    import * as zlib from 'node:zlib';
+    import { Logger as SiglensLogger } from './lib/siglenslogger.mjs';
+
+    const loggerConfig = {
+        url: process.env.SIGLENS_INGEST_URL,
+        token: process.env.SIGLENS_TOKEN,
+    };
+    const logger = new SiglensLogger(loggerConfig);
+
+    export const handler = (event, context, callback) => {
+        console.log('Received event:', JSON.stringify(event, null, 2));
+
+        // CloudWatch Logs data is base64 encoded so decode here
+        const payload = Buffer.from(event.awslogs.data, 'base64');
+        // CloudWatch Logs are gzip compressed so expand here
+        zlib.gunzip(payload, (err, result) => {
+            if (err) {
+                callback(err);
+            } else {
+                const parsed = JSON.parse(result.toString('ascii'));
+                console.log('Decoded payload:', JSON.stringify(parsed, null, 2));
+                let count = 0;
+                if (parsed.logEvents) {
+                    parsed.logEvents.forEach((item) => {
+                        /* Log event to SigLens with explicit event timestamp.
+                        - Use optional 'context' argument to send Lambda metadata e.g. awsRequestId, functionName.
+                        - Change "item.timestamp" below if time is specified in another field in the event.
+                        - Change to "logger.log(item.message, context)" if no time field is present in event. */
+                        logger.logWithTime(item.timestamp, item.message, context);
+
+                        /* Alternatively, UNCOMMENT logger call below to override default input settings */
+                        /* Log event to SigLens with any combination of explicit timestamp, index, source, sourcetype, and host.*/
+                        // logger.logEvent({
+                        //     timestamp: new Date(item.timestamp).getTime() / 1000,
+                        //     host: 'serverless',
+                        //     source: `lambda:${context.functionName}`,
+                        //     sourcetype: 'httpevent',
+                        //     index: 'main',
+                        //     event: item.message,
+                        // });
+
+                        count += 1;
+                    });
+                }
+                // Send all the events in a single batch to SigLens
+                logger.flushAsync((error, response) => {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        console.log(`Response from SigLens:\n${response}`);
+                        console.log(`Successfully processed ${count} log event(s).`);
+                        callback(null, count); // Return number of log events
+                    }
+                });
+            }
+        });
+    };
+
+    ```
+    </details>
+
+    </TabItem>
+    </Tabs>
+
+2. Create a `lib` folder and create `siglenslogger.mjs` file inside the `lib` folder, input the below code, and save.
+
+    <Tabs
+    className="bg-light"
+    defaultValue="nodejs"
+    values={[
+        {label: 'Node.js', value: 'nodejs'},
+    ]
+    }>
+
+    <TabItem value="nodejs">
+
+    <details>
+    <summary>lib/siglenslogger.mjs</summary>
+
+    ```javascript
+    import * as url from 'node:url';
+    import { createRequire } from 'node:module';
+        
+    const require = createRequire(import.meta.url);
+
+    const Logger = function Logger(config) {
+        this.url = config.url;
+        this.token = config.token;
+
+        this.addMetadata = true;
+        this.setSource = true;
+
+        this.parsedUrl = url.parse(this.url);
+        // eslint-disable-next-line import/no-dynamic-require
+        this.requester = require(this.parsedUrl.protocol.substring(0, this.parsedUrl.protocol.length - 1));
+        // Initialize request options which can be overridden & extended by consumer as needed
+        this.requestOptions = {
+            hostname: this.parsedUrl.hostname,
+            path: this.parsedUrl.path,
+            port: this.parsedUrl.port,
+            method: 'POST',
+            headers: {
+                Authorization: `${this.token}`,
+            },
+            rejectUnauthorized: false,
+        };
+
+        this.payloads = [];
+    };
+
+    // Simple logging API for Lambda functions
+    Logger.prototype.log = function log(message, context) {
+        this.logWithTime(Date.now(), message, context);
+    };
+
+    Logger.prototype.logWithTime = function logWithTime(time, message, context) {
+        const payload = {};
+
+        if (Object.prototype.toString.call(message) === '[object Array]') {
+            throw new Error('message argument must be a string or a JSON object.');
+        }
+        payload.event = message;
+
+        // Add Lambda metadata
+        if (typeof context !== 'undefined') {
+            if (this.addMetadata) {
+                // Enrich event only if it is an object
+                if (message === Object(message)) {
+                    payload.event = JSON.parse(JSON.stringify(message)); // deep copy
+                    payload.event.awsRequestId = context.awsRequestId;
+                }
+            }
+            if (this.setSource) {
+                payload.source = `lambda:${context.functionName}`;
+            }
+        }
+
+        payload.timestamp = new Date(time).getTime() / 1000;
+
+        this.logEvent(payload);
+    };
+
+    Logger.prototype.logEvent = function logEvent(payload) {
+        this.payloads.push(JSON.stringify(payload));
+    };
+
+    Logger.prototype.flushAsync = function flushAsync(callback) {
+        callback = callback || (() => {}); // eslint-disable-line no-param-reassign
+
+        console.log('Sending event(s)');
+        const req = this.requester.request(this.requestOptions, (res) => {
+            res.setEncoding('utf8');
+
+            console.log('Response received');
+            res.on('data', (data) => {
+                let error = null;
+                if (res.statusCode !== 200) {
+                    error = new Error(`error: statusCode=${res.statusCode}\n\n${data}`);
+                    console.error(error);
+                }
+                this.payloads.length = 0;
+                callback(error, data);
+            });
+        });
+
+        req.on('error', (error) => {
+            callback(error);
+        });
+
+        req.end(this.payloads.join(''), 'utf8');
+    };
+
+    export { Logger };
+
+    ```
+    </details>
+
+    </TabItem>
+    </Tabs>
+
+3. Click **Deploy**.
+
+### 5. Testing and Verification
+1. Generate logs in CloudWatch.
+2. Wait 10-15 seconds and verify logs in SigLens UI.

--- a/docs/migration/awscloudwatch/fluentd.md
+++ b/docs/migration/awscloudwatch/fluentd.md
@@ -15,7 +15,7 @@ Install [Fluentd](https://docs.fluentd.org/installation) on your server.
 
 ### 2. IAM Role Configuration
 
-1. Create an IAM role with the below permissions.
+1. Create an IAM role with the following permissions to allow Fluentd to access CloudWatch Logs:
 
     ```json
     {
@@ -32,10 +32,22 @@ Install [Fluentd](https://docs.fluentd.org/installation) on your server.
         ]
     }
     ```
-2. Obtain IAM Role Access Key and Secret Key for authentication.
-3. This is required for the Authentication purposes.
+2. For authentication purposes, Fluentd requires the IAM Role's Access Key ID and Secret Access Key:
+- **For EC2 instances**: If Fluentd is running on an EC2 instance, instead of manually managing Access Keys, it's recommended to use an IAM role attached to the EC2 instance. This approach simplifies credential management and enhances security. 
 
-**Note**: For EC2 instances, use an *`IAM service role`* instead.
+    1. Navigate to the EC2 dashboard within the AWS Management Console.
+    2. Select the instance you want to attach the IAM role to.
+    3. In the `Actions` menu, choose `Security`, then `Modify IAM role`.
+    4. Choose the IAM role that has the necessary permissions outlined above from the dropdown list.
+    5. Click `Save` to attach the role to the instance.
+
+    By attaching an IAM role, EC2 instances will automatically have access to AWS services based on the role's permissions without the need for Access Keys.
+- **For non-EC2 setups**: If Fluentd is not running on an EC2 instance, you will need to manually manage and provide Access Keys for authentication.
+
+    1. Navigate to the IAM console.
+    2. Find the IAM role you created with the necessary permissions.
+    3. Under the `Security credentials` tab, create a new Access Key.
+    4. Securely store the Access Key ID and Secret Access Key presented to you.
 
 ### 3. Environment Setup (skip if using EC2 IAM role)
 

--- a/docs/migration/awscloudwatch/fluentd.md
+++ b/docs/migration/awscloudwatch/fluentd.md
@@ -1,0 +1,119 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fluentd
+
+*Migrating/Stream Logs from AWS CloudWatch to SigLens through Fluentd.*
+
+
+**Prerequisites**: AWS account with logs in CloudWatch Logs Group.
+
+
+## 1. Fluentd Installation
+
+Install [Fluentd](https://docs.fluentd.org/installation) on your server.
+
+### 2. IAM Role Configuration
+
+1. Create an IAM role with the below permissions.
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": [
+                    "logs:GetLogEvents",
+                    "logs:DescribeLogStreams"
+                ],
+                "Effect": "Allow",
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+2. Obtain IAM Role Access Key and Secret Key for authentication.
+3. This is required for the Authentication purposes.
+
+**Note**: For EC2 instances, use an *`IAM service role`* instead.
+
+### 3. Environment Setup (skip if using EC2 IAM role)
+
+#### Export AWS credentials and region:
+
+    ```bash
+    export AWS_REGION=us-east-1
+    export AWS_ACCESS_KEY_ID="YOUR_ACCESS_KEY"
+    export AWS_SECRET_ACCESS_KEY="YOUR_SECRET_ACCESS_KEY"
+    ```
+
+### 4. [CloudWatch Logs Plugin Installation](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs)
+
+#### For Fluentd
+
+    ```bash
+    gem install fluent-plugin-cloudwatch-logs
+    ```
+
+#### For td-agent
+
+    ```bash
+    td-agent-gem install fluent-plugin-cloudwatch-logs
+    ```
+
+### 5. Fluentd Configuration
+
+- Read more about the [Fluentd CloudWatch source configuration from here](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs?tab=readme-ov-file#in_cloudwatch_logs)
+
+```xml title="fluentd.conf"
+<source>
+  @type cloudwatch_logs
+  tag cloudwatch.your_tag
+  region us-east-1
+  log_group_name "/aws/lambda/siglensSaasOrgsStats"
+  #use_log_group_name_prefix true
+  log_stream_name "2024"
+  use_log_stream_name_prefix true  # To Stream all the Logs from the log streams that start with name 2024.
+  state_file /var/lib/fluent/group_stream.in.state1
+  <parse>
+    @type none
+    #@type json   # if your cloudwatch logs are in json.
+  </parse>
+</source>
+
+<match cloudwatch.*>
+  @type http
+  endpoint http://127.0.0.1:8081/services/collector/event
+  open_timeout 2
+  <format>
+    @type json
+  </format>
+  <buffer>
+    flush_interval 5s
+  </buffer>
+</match>
+```
+
+- For log record transformation or filtering, leverage Fluentd’s filter plugin. Detailed guidance can be found in the [Fluentd documentation](https://docs.fluentd.org/configuration).
+
+### 3. Run Fluentd
+
+<Tabs
+  className="bg-light"
+  defaultValue="unix"
+  values={[
+    {label: 'Linux', value: 'unix'}
+  ]
+}>
+
+<TabItem value="unix">
+Navigate to the Fluentd directory and run the following command. If using td-agent, replace `fluentd` with `td-agent`.
+
+```bash
+sudo fluentd -c /home/fluentd.conf
+```
+</TabItem>
+
+</Tabs>
+
+Make sure to set the correct path to Fluentd and its config file.

--- a/sidebars.js
+++ b/sidebars.js
@@ -116,6 +116,16 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Migrating from AWS CloudWatch',
+      link: {
+        type: 'generated-index',
+        title: 'Migrating from AWS CloudWatch',
+        description: `Migrating/Streaming Logs from AWS CloudWatch to Siglens is a simple process. Please follow the below steps to migrate to Siglens.`,
+      },
+      items: ['migration/awscloudwatch/aws-lambda', 'migration/awscloudwatch/fluentd'],
+    },
+    {
+      type: 'category',
       label: 'Migrating from Datadog',
       link: {
         type: 'generated-index',


### PR DESCRIPTION
# Description
- Added documentation for Migrating logs from AWS CloudWatch through
   1. AWS Lambda
   2. Fluentd.


This is the Netlify link: https://aws-cloudwatch-siglens-deploy--singular-kelpie-6480de.netlify.app/category/migrating-from-aws-cloudwatch