### PR TITLE
Alphabetize Splunk commands

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -147,6 +147,7 @@ const sidebars = {
   'spl-docs/bin-command',
   'spl-docs/dedup-command',
   'spl-docs/eval-command',
+  'spl-docs/extract-command',
   'spl-docs/fields-command',
   'spl-docs/fillnull-command',
   'spl-docs/gentimes-command',
@@ -167,7 +168,6 @@ const sidebars = {
   'spl-docs/top-command',
   'spl-docs/transaction-command',
   'spl-docs/where-command',
-  'spl-docs/extract-command',
 {
   type: 'category',
   label: 'Evaluation Functions',


### PR DESCRIPTION
Now the items show up in alphabetic order
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/50169855-29dd-47fe-a18c-36e8f409ae5b">
